### PR TITLE
(KW-186) API Reaches rate limit against Coin Gecko

### DIFF
--- a/jest.env
+++ b/jest.env
@@ -1,8 +1,11 @@
 DEPLOY_ENV=local
-FIREBASE_PROJECT_ID=xxx
-EXCHANGE_RATES_API=https://apilayer.net/api
-BLOCKSCOUT_API=https://alfajores-blockscout.celo-testnet.org/graphql
-FIREBASE_DB=xxx
+COINGECKO_API=https://api.coingecko.com/api/v3
+FIREBASE_PROJECT_ID=kolektivo-backend-prod-default-rtdb
+EXCHANGE_RATES_API=https://api.apilayer.com/currency_data
+BLOCKSCOUT_API=https://rc1-blockscout.celo-testnet.org
+FIREBASE_DB=kolektivo-backend-prod-default-rtdb
 FAUCET_ADDRESS=0x456f41406B32c45D59E539e4BBA3D7898c3584dA
-VERIFICATION_REWARDS_ADDRESS=0xb4fdaf5f3cd313654aa357299ada901b1d2dd3b5
-WEB3_PROVIDER_URL=https://alfajores-forno.celo-testnet.org
+VERIFICATION_REWARDS_ADDRESS=0x00000000000000000000000000000000000verif
+WEB3_PROVIDER_URL=https://forno.celo.org
+EXCHANGES_NETWORK_CONFIG=mainnet
+SECRET_NAMES='projects/537878594312/secrets/blockchain-api/versions/1,projects/537878594312/secrets/blockchain-psql/versions/6'

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "jest": "^27.4.2",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.5.0",
+    "sqlite3": "^5.1.2",
     "ts-jest": "^27.0.7",
     "tsc-watch": "^5.0.3",
     "typescript": "4.7.4"

--- a/src/currencyConversion/CurrencyConversionAPI.test.ts
+++ b/src/currencyConversion/CurrencyConversionAPI.test.ts
@@ -81,7 +81,6 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'USD',
       currencyCode: 'cGLD',
     })
-    expect(result).toEqual(new BigNumber(10))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
     expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(1)
     expect(result).toEqual(new BigNumber(15))
@@ -94,7 +93,6 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'MXN',
       impliedExchangeRates,
     })
-    expect(result).toEqual(new BigNumber(200))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
     expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
     expect(result).toEqual(new BigNumber(200))
@@ -105,7 +103,6 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'MXN',
       currencyCode: 'cGLD',
     })
-    expect(result).toEqual(new BigNumber(200))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
     expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(1)
     expect(result).toEqual(new BigNumber(300))
@@ -116,7 +113,6 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'USD',
       currencyCode: 'MXN',
     })
-    expect(result).toEqual(new BigNumber(20))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
     expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
     expect(result).toEqual(new BigNumber(20))
@@ -171,7 +167,6 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'EUR',
     })
 
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledWith({
     expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
       sourceCurrencyCode: 'cGLD',
       currencyCode: 'cUSD',
@@ -188,7 +183,6 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'EUR',
       currencyCode: 'cGLD',
     })
-    expect(result).toEqual(new BigNumber(200))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
       sourceCurrencyCode: 'EUR',
       currencyCode: 'USD',
@@ -230,5 +224,35 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'cGLD',
     })
     expect(result).toEqual(new BigNumber(300))
+  })
+
+  it('should retrieve rate for TTD/cEUR', async () => {
+    const result = await currencyConversionAPI.getExchangeRate({
+      currencyCode: 'TTD',
+      sourceCurrencyCode: 'cEUR'
+    })
+
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      currencyCode: 'TTD',
+      sourceCurrencyCode: 'USD',
+    })
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
+      currencyCode: 'USD',
+      sourceCurrencyCode: 'cEUR'
+    })
+    expect(result).toEqual(new BigNumber(300))
+  })
+
+  it('should retrieve rate for TTD/GBR', async () => {
+    const result = await currencyConversionAPI.getExchangeRate({
+      currencyCode: 'TTD',
+      sourceCurrencyCode: 'GBR'
+    })
+
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      currencyCode: 'TTD',
+      sourceCurrencyCode: 'GBR',
+    })
+    expect(result).toEqual(new BigNumber(20))
   })
 })

--- a/src/currencyConversion/CurrencyConversionAPI.test.ts
+++ b/src/currencyConversion/CurrencyConversionAPI.test.ts
@@ -7,6 +7,7 @@ import OracleJsonAPI from './OracleJsonAPI'
 
 jest.mock('./ExchangeRateAPI')
 jest.mock('./GoldExchangeRateAPI')
+jest.mock('./OracleJsonAPI')
 
 const mockDefaultGetExchangeRate = ExchangeRateAPI.prototype
   .getExchangeRate as jest.Mock
@@ -46,9 +47,9 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'cUSD',
       impliedExchangeRates,
     })
-    expect(result).toEqual(new BigNumber(10))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(10))
   })
 
   it('should retrieve rate for cUSD/cGLD', async () => {
@@ -56,9 +57,10 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'cUSD',
       currencyCode: 'cGLD',
     })
-    expect(result).toEqual(new BigNumber(10))
+    
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(new BigNumber(15))
   })
 
   it('should retrieve rate for cGLD/USD', async () => {
@@ -68,10 +70,10 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'USD',
       impliedExchangeRates,
     })
-    expect(result).toEqual(new BigNumber(10))
 
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(10))
   })
 
   it('should retrieve rate for USD/cGLD', async () => {
@@ -81,7 +83,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(10))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(new BigNumber(15))
   })
 
   it('should retrieve rate for cGLD/MXN', async () => {
@@ -93,7 +96,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(200))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(200))
   })
 
   it('should retrieve rate for MXN/cGLD', async () => {
@@ -103,7 +107,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(200))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(new BigNumber(300))
   })
 
   it('should retrieve rate for USD/MXN', async () => {
@@ -113,7 +118,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(20))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(20))
   })
 
   it('should retrieve rate for MXN/USD', async () => {
@@ -123,7 +129,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(20))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(20))
   })
 
   it('should retrieve rate for cUSD/MXN', async () => {
@@ -133,7 +140,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(20))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(20))
   })
 
   it('should retrieve rate for MXN/cUSD', async () => {
@@ -143,7 +151,8 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(20))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(20))
   })
 
   it('should return 1 when using the same currency code', async () => {
@@ -151,9 +160,9 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'ABC',
       currencyCode: 'ABC',
     })
-    expect(result).toEqual(new BigNumber(1))
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(1))
   })
 
   it('should retrieve rate for cGLD/EUR', async () => {
@@ -161,9 +170,9 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'cGLD',
       currencyCode: 'EUR',
     })
-    expect(result).toEqual(new BigNumber(200))
 
     expect(mockGoldGetExchangeRate).toHaveBeenCalledWith({
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
       sourceCurrencyCode: 'cGLD',
       currencyCode: 'cUSD',
     })
@@ -171,6 +180,7 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'USD',
       currencyCode: 'EUR',
     })
+    expect(result).toEqual(new BigNumber(300))
   })
 
   it('should retrieve rate for EUR/cGLD', async () => {
@@ -179,14 +189,46 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'cGLD',
     })
     expect(result).toEqual(new BigNumber(200))
-
     expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
       sourceCurrencyCode: 'EUR',
       currencyCode: 'USD',
     })
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledWith({
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
       sourceCurrencyCode: 'cUSD',
       currencyCode: 'cGLD',
     })
+    expect(result).toEqual(new BigNumber(300))
+  })
+
+  it('should retrieve rate for cGLD/cEUR', async () => {
+    const result = await currencyConversionAPI.getExchangeRate({
+      sourceCurrencyCode: 'cGLD',
+      currencyCode: 'cEUR'
+    })
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'USD',
+      currencyCode: 'EUR',
+    })
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'cGLD',
+      currencyCode: 'cUSD',
+    })
+    expect(result).toEqual(new BigNumber(300))
+  })
+
+  it('should retrieve rate for cEUR/cGLD', async () => {
+    const result = await currencyConversionAPI.getExchangeRate({
+      sourceCurrencyCode: 'cEUR',
+      currencyCode: 'cGLD'
+    })
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'EUR',
+      currencyCode: 'USD',
+    })
+    expect(mockDefaultGetOracleRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'cUSD',
+      currencyCode: 'cGLD',
+    })
+    expect(result).toEqual(new BigNumber(300))
   })
 })

--- a/src/currencyConversion/CurrencyConversionAPI.ts
+++ b/src/currencyConversion/CurrencyConversionAPI.ts
@@ -141,6 +141,16 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
       ) {
         return [fromCode, this.getCurrency(toCode), toCode]
       }
+      else if (
+        toCode === CEUR && this.getCurrency(toCode) !== fromCode
+      ) {
+        return [fromCode, USD, toCode]
+      }
+      else if (
+        fromCode === CEUR && this.getCurrency(fromCode) !== toCode
+      ) {
+        return [fromCode, USD, toCode]
+      }
     }
     return [fromCode, toCode]
   }

--- a/src/currencyConversion/OracleJsonAPI.ts
+++ b/src/currencyConversion/OracleJsonAPI.ts
@@ -1,22 +1,13 @@
 import { RESTDataSource } from 'apollo-datasource-rest'
-import { metrics } from '../metrics'
-import { COINGECKO_API } from '../config'
-import { enumValueForKey, getCurrency, supportedOracleTokens } from './consts'
+import { CELO, CGLD, CUSD, USD } from './consts'
 import BigNumber from 'bignumber.js'
 import { logger } from '../logger'
 import { CurrencyConversionArgs } from '../resolvers'
-import { formatDateStringShort } from '../utils'
-
-interface OracleApiResult {
-  market_data: { current_price: { [currencyCode: string]: number } }
-}
-
-const MIN_TTL = 12 * 3600 // 12 hours
+import tokenInfoCache, { TokenInfo } from '../helpers/TokenInfoCache'
 
 export default class OracleJsonAPI extends RESTDataSource {
   constructor() {
     super()
-    this.baseURL = `${COINGECKO_API}`
   }
 
   async getExchangeRate({
@@ -25,17 +16,26 @@ export default class OracleJsonAPI extends RESTDataSource {
     timestamp,
   }: CurrencyConversionArgs): Promise<BigNumber> {
     try {
+      // Note: Can be any pair in `supportedPairs`
+      const toToken = (sourceCurrencyCode === CGLD ? CELO : sourceCurrencyCode) || CUSD;
+      const fromToken = currencyCode === CGLD ? CELO : currencyCode;
       const pair = `${sourceCurrencyCode}/${currencyCode}`
-      const rates = await this.getOracleRate(
-        sourceCurrencyCode || supportedOracleTokens.cUSD,
-        currencyCode,
-        timestamp,
-      )
-      const payload = Object.assign({}, rates.market_data.current_price)
-      if (!payload[getCurrency(currencyCode)]) {
+      // Note: If converting from cUSD -> X, 
+      // then the rate needs to be inverted
+      let rate;
+      if (toToken === CUSD || toToken === USD) {
+        rate = this.getFirebaseRate(fromToken)
+      } else if (fromToken === CUSD || fromToken == USD) {
+        const temp = await this.getFirebaseRate(toToken);
+        rate = new BigNumber(1).dividedBy(temp)
+      }
+      
+      if (!rate) {
         throw new Error(`Unable to get rate for pair: ${pair}`)
       }
-      return new BigNumber(payload[getCurrency(currencyCode)])
+
+      logger.info(rate.toString())
+      return rate
     } catch (error) {
       logger.error({
         type: 'ERROR_UPDATING_ORACLE_PRICES',
@@ -45,37 +45,21 @@ export default class OracleJsonAPI extends RESTDataSource {
     }
   }
 
-  async getOracleRate(
-    sourceCurrencyCode: string,
-    currencyCode: string,
-    timestamp: number = Date.now(),
-  ): Promise<OracleApiResult> {
-    const t0 = performance.now()
-    const date = new Date(Date.now())
-    const path = `/coins/${enumValueForKey(
-      supportedOracleTokens,
-      sourceCurrencyCode,
-    )}/history`
-    const params = {
-      date: formatDateStringShort(new Date(timestamp)),
-    }
-    const result = await this.get<OracleApiResult>(path, params, {
-      cacheOptions: { ttl: this.getCacheTtl(date) },
-    })
-    if (Object.is(result, {})) {
-      throw new Error(`Invalid response from oracle: ${JSON.stringify(result)}`)
-    }
-    const t1 = performance.now()
-    metrics.setQueryOracleRateDuration(t1 - t0)
-    return result
-  }
-
-  private getCacheTtl(date: Date) {
-    if (Date.now() - date.getTime() >= 24 * 3600 * 1000) {
-      // Cache indefinitely if requesting a date prior to the last 24 hours
-      return Number.MAX_SAFE_INTEGER
-    } else {
-      return MIN_TTL
-    }
+  /**
+   * This function returns the currently stored USD price of a 
+   * given crypto asset by address.
+   * 
+   * e.g. cGLD -> USD = 13.034094
+   * @param tokenAddress Address of Asset to return USD Price
+   * @returns {Promise<BigNumber>}
+   */
+  async getFirebaseRate(
+    currency: string,
+  ): Promise<BigNumber> {
+    logger.info(currency)
+    const tokenInfo: TokenInfo | undefined = tokenInfoCache.tokenInfoBySymbol(currency)
+    const usdPrice: BigNumber = new BigNumber(tokenInfo?.usdPrice ?? 0)
+    logger.info(tokenInfo)
+    return usdPrice;
   }
 }

--- a/src/currencyConversion/consts.ts
+++ b/src/currencyConversion/consts.ts
@@ -7,18 +7,18 @@ export const EUR = 'EUR'
 export const USD = 'USD'
 export const CELO = 'CELO'
 export enum supportedStableTokens {
-  CEUR,
   CUSD,
 }
 export enum supportedCurrencies {
-  EUR,
   USD,
 }
 export enum supportedPairs {
   'cGLD/cUSD',
   'cUSD/cGLD',
-  'cGLD/cEUR',
-  'cEUR/cGLD',
+  'cEUR/USD',
+  'cEUR/cUSD',
+  'USD/cEUR',
+  'cUSD/cEUR'
 }
 export enum stablePairs {
   'cUSD/USD',

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -26,7 +26,15 @@ export async function initDatabase({
   }
 }) {
   let db: Knex
-  if (client === 'pg') {
+  if (client === 'sqlite3') {
+    db = knex({
+      client: 'sqlite3',
+      connection: {
+        filename: ':memory:',
+      },
+      useNullAsDefault: true,
+    })
+  } else if (client === 'pg') {
     db = knex({
       client: 'pg',
       connection,

--- a/src/helpers/TokenInfoCache.ts
+++ b/src/helpers/TokenInfoCache.ts
@@ -11,6 +11,7 @@ export interface TokenInfo {
   priceFetchedAt?: number
   isCoreToken?: boolean
   pegTo?: string
+  usdPrice?: string
 }
 
 interface TokensInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,21 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz#8e6735ccebbb1581e5a7e652244cadc8a844d03c"
+  integrity sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==
+  dependencies:
+    detect-libc "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.7"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -2757,6 +2772,14 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
+are-we-there-yet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
+  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
 
 are-we-there-yet@^3.0.0:
   version "3.0.0"
@@ -4125,7 +4148,7 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color-support@^1.1.3:
+color-support@^1.1.2, color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
@@ -4296,7 +4319,7 @@ connect@^3.6.2:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-console-control-strings@^1.1.0:
+console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
@@ -4835,6 +4858,11 @@ destroy@^1.0.4, destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-libc@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -6322,6 +6350,21 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gauge@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
+  dependencies:
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.2"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.1"
+    object-assign "^4.1.1"
+    signal-exit "^3.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.2"
 
 gauge@^4.0.3:
   version "4.0.4"
@@ -9102,7 +9145,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0:
+make-dir@^3.0.0, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -9727,6 +9770,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-addon-api@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
+  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
+
 node-cleanup@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz"
@@ -9781,7 +9829,7 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
-node-gyp@^8, node-gyp@^8.0.0:
+node-gyp@8.x, node-gyp@^8, node-gyp@^8.0.0:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
   integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
@@ -9859,6 +9907,16 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npmlog@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
 
 npmlog@^6.0.0:
   version "6.0.2"
@@ -11912,6 +11970,17 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sqlite3@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.2.tgz#f50d5b1482b6972fb650daf6f718e6507c6cfb0f"
+  integrity sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^4.2.0"
+    tar "^6.1.11"
+  optionalDependencies:
+    node-gyp "8.x"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -14048,7 +14117,7 @@ wide-align@1.1.3:
   dependencies:
     string-width "^1.0.2 || 2"
 
-wide-align@^1.1.5:
+wide-align@^1.1.2, wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

* Removes dependency on Coin Gecko
* Places dependency on Firebase USD prices for CELO, CEUR

Drawbacks:

* Loses historical price data, since Firebase only stores current prices (to the minute)

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

* Unit test for `CurrencyConvertor` updated to reflect new currency restraints.
* cEUR is no longer treated as a supported stable coin, instead it will be converted using the following logic:
   * [cEUR -> EUR -> USD -> X] where X is CUSD, CELO, or a supported FIAT currency